### PR TITLE
[#22] Fix STEP_0103 Issue by adding shorted

### DIFF
--- a/STEP_0103_read_chirps_create_precip_netcdf_and_spi_netcdf.py
+++ b/STEP_0103_read_chirps_create_precip_netcdf_and_spi_netcdf.py
@@ -301,7 +301,7 @@ class StandardizedPrecipitationIndex:
         min_range = min(self.__spi_periods)
         max_range = max(self.__spi_periods)
         try:
-            chirps_files = self.__fileHandler.get_working_file_names('chirps_netcdf_regex')
+            chirps_files = sorted(self.__fileHandler.get_working_file_names('chirps_netcdf_regex'))
 
             # get the valid times of the totals #
             self.__precip_times = self.__get_calendar_times(chirps_files, self.__working_chirps_file_match)


### PR DESCRIPTION
Windows internal directory lists are date sorted…Linux ones are not. This is causing the precipitation and SPI files to have dates out of order. That is why the STEP_0301 script is detecting the incorrect range for the SPI data.